### PR TITLE
Colorize file as well as adb output

### DIFF
--- a/adb-logcat-color.rb
+++ b/adb-logcat-color.rb
@@ -3,7 +3,7 @@
 require 'rubygems'
 require 'smart_colored/extend'
 
-patterns = {"V/" => {:fg => "black", :bg => "blue",    :label => "[ VERBOSE ]"},
+$patterns = {"V/" => {:fg => "black", :bg => "blue",    :label => "[ VERBOSE ]"},
             "D/" => {:fg => "black", :bg => "cyan",    :label => "[  DEBUG  ]"},
             "I/" => {:fg => "black", :bg => "green",   :label => "[  INFO   ]"},
             "W/" => {:fg => "black", :bg => "yellow",  :label => "[ WARNING ]"},
@@ -11,24 +11,36 @@ patterns = {"V/" => {:fg => "black", :bg => "blue",    :label => "[ VERBOSE ]"},
             "F/" => {:fg => "black", :bg => "magenta", :label => "[  FATAL  ]"},
             "S/" => {:fg => "black", :bg => "white",   :label => "[  SILENT ]"}}
 
+def colorize_line(line)
+  line.sub!(/\(\s*\d+\)/, "")
+  line.gsub!("\r\n", "")
 
-# Ruby 1.9 support passing an array - move to this eventually
-IO.popen("adb logcat #{ARGV.join(' ')}") do |f|
-  while line = f.gets
-    line.sub!(/\(\s*\d+\)/, "")
-    line.gsub!("\r\n", "")
+  match = $patterns.keys.find do |x|
+    line.start_with?(x)
+  end
 
-    match = patterns.keys.find do |x|
-      line.start_with?(x)
-    end
+  if match
+    line.sub!(match, " => ")
+    label = $patterns[match][:label]
+    fg = $patterns[match][:fg]
+    bg = $patterns[match][:bg]
+    print label.send("#{fg}_on_#{bg}")
+    puts line.send("#{bg}_on_#{fg}")
+  end
+end
 
-    if match
-      line.sub!(match, " => ")
-      label = patterns[match][:label]
-      fg = patterns[match][:fg]
-      bg = patterns[match][:bg]
-      print label.send("#{fg}_on_#{bg}")
-      puts line.send("#{bg}_on_#{fg}")
+use_argf=ARGV.length == 1 and File.exists?(ARGV[0])
+
+if use_argf then
+  ARGF.each do |line|
+    colorize_line(line)
+  end
+else
+  # Ruby 1.9 support passing an array - move to this eventually
+  IO.popen("adb logcat #{ARGV.join(' ')}") do |f|
+    while line = f.gets
+      colorize_line(line)
     end
   end
 end
+


### PR DESCRIPTION
If passed one argument which is a file then logcat will read/colorize
that files contents and write to stdout. Otherwise will behave as
before by colorizing output of "adb logcat".

Note, I wanted to also support reading from STDIN, but didn't see a clean way of doing this. Ideally I'd like to run logcat in one of three ways:
1. logcat // reads stdout of "adb logcat"
2. logcat saved_output.txt // Colorize saved_output.txt to stdout
3. cat saved_output.txt | logcat // Colorize stdin to stdout

This change adds #2, and I'll do #3 when I have the need (or when asked).
